### PR TITLE
Adding amrex gallery link to validation repo

### DIFF
--- a/JAMES_Paper/Flow_Over_Terrain/README.md
+++ b/JAMES_Paper/Flow_Over_Terrain/README.md
@@ -2,7 +2,7 @@
 
 Details regarding the Witch of Agnesi (WOA) test case may be found in [Sridhar et al. (2022)](https://doi.org/10.5194/gmd-15-6259-2022).
     
-Results presented herein were generated with ERF hash: **9428c70** and inputs file: `inputs name`.
+Results presented herein were generated with ERF hash: **9428c70** and inputs file: [inputs](https://github.com/erf-model/ERF/tree/development/Exec/DryRegTests/WitchOfAgnesi/inputs).
      
 Specification of the terrain height at the bottom of the domain follows $z(x) = \frac{h_{m} a^2}{\left( x - x_c\right)^2 + a^2}$, where $h_m$ = 1[m] and $a = 1000$ [m]. The domain lengths are $(L_x, L_z) = (144\times 10^3, 20\times 10^3)$ [m] and the  horizontal direction has a uniform grid resolution of $\Delta x = 500$ [m]. The mesh is geometrically stretched in the vertical to provide improved resolution near the hill; an initial spacing of 0.1 [m] and a stretching ratio of 1.05 is utilized in the vertical direction. The simulation is run for 3 hours, with an RK3 time step of 0.03 [s] and 4 acoustic sub-steps in the last RK stage. Inflow-outflow boundary conditions were applied in the stream-wise direction, with a 10 [m/s] inflow velocity, and slip walls were utilized at the top and bottom. The $3^{\rm rd}$ order upwind scheme was used for advection. This test case is purely inviscid and dry.
 

--- a/JAMES_Paper/Supercell/README.md
+++ b/JAMES_Paper/Supercell/README.md
@@ -1,6 +1,6 @@
 # Three-dimensional super cell
 
-Details regarding the Super Cell test case may be found in [Tissaoui et al. (2023)](https://doi.org/10.1029/2022MS003283).
+Details regarding the Super Cell test case may be found in [Tissaoui et al. (2023)](https://doi.org/10.1029/2022MS003283). The simulation can be found in the [AMReX Gallery](https://amrex-codes.github.io/amrex/gallery.html) under the section - Thunderstorm in ERF.
 
 Results presented herein were generated with ERF hash: **653f9e3** and the inputs file [3DSupercell](https://github.com/erf-model/ERF/blob/653f9e3eb4c9403815458765855b636455e39a45/Exec/MoistRegTests/SuperCell_3D/inputs_moisture_Tissaoui).
 

--- a/JAMES_Paper/Supercell/README.md
+++ b/JAMES_Paper/Supercell/README.md
@@ -1,6 +1,6 @@
 # Three-dimensional super cell
 
-Details regarding the Super Cell test case may be found in [Tissaoui et al. (2023)](https://doi.org/10.1029/2022MS003283). The simulation can be found in the [AMReX Gallery](https://amrex-codes.github.io/amrex/gallery.html) under the section - Thunderstorm in ERF.
+Details regarding the Super Cell test case may be found in [Tissaoui et al. (2023)](https://doi.org/10.1029/2022MS003283). A rendering of the simulation can be found in the [AMReX Gallery](https://amrex-codes.github.io/amrex/gallery.html) under the section - Thunderstorm in ERF.
 
 Results presented herein were generated with ERF hash: **653f9e3** and the inputs file [3DSupercell](https://github.com/erf-model/ERF/blob/653f9e3eb4c9403815458765855b636455e39a45/Exec/MoistRegTests/SuperCell_3D/inputs_moisture_Tissaoui).
 


### PR DESCRIPTION
This PR adds the link to the amrex gallery for the 3D supercell animation and the `inputs` file for the FlowOverTerrain case.